### PR TITLE
New command: find-by-name

### DIFF
--- a/exe/dingo-postgresql-clusterdata-backup
+++ b/exe/dingo-postgresql-clusterdata-backup
@@ -4,13 +4,13 @@ require 'fog'
 require 'json'
 
 def usage
-  $stderr.puts "USAGE: FOG_RC=path/to/fog.yml dingo-postgresql-clusterdata-backup [backup|restore|list-service-ids|display-backups|find-by-name]"
+  $stderr.puts "USAGE: FOG_RC=path/to/fog.yml dingo-postgresql-clusterdata-backup [backup|restore|list-service-ids|find-by-name]"
   exit 1
 end
 
 command=ARGV.shift
 usage if command.nil?
-usage unless %w[backup restore list-service-ids display-backups find-by-name].include?(command)
+usage unless %w[backup restore list-service-ids find-by-name].include?(command)
 case command
 when 'backup'
   if $stdin.tty?
@@ -67,33 +67,6 @@ when 'list-service-ids'
     service_ids
   }
   puts service_ids
-when 'display-backups'
-  simultaneous_downloads = 5
-  require 'thread'
-  work_q = Queue.new
-  bucket.files.each{|file| work_q.push(file) }
-  workers = (0...simultaneous_downloads).map do
-    Thread.new do
-      begin
-        while file = work_q.pop(true)
-          begin
-            if file.key =~ %r{^dingo-postgresql-clusterdata-backup-(.*).json$}
-              json_str = file.body
-              backup_data = JSON.parse(json_str)
-              instance_id = backup_data['instance_id']
-              space_guid = backup_data['space_guid']
-              name = backup_data['service_instance_name'] || 'no-name'
-              puts "#{name}\t| #{instance_id} | #{space_guid}"
-            end
-          rescue JSON::ParserError
-            $stderr.puts "Failed to parse #{file.key}: #{json_str}"
-          end
-        end
-      rescue ThreadError
-      end
-    end
-  end
-  workers.map(&:join)
 when 'find-by-name'
   input = JSON.parse($stdin.read)
   find_name = input['name']

--- a/exe/dingo-postgresql-clusterdata-backup
+++ b/exe/dingo-postgresql-clusterdata-backup
@@ -10,7 +10,7 @@ end
 
 command=ARGV.shift
 usage if command.nil?
-usage unless %w[backup restore list-service-ids].include?(command)
+usage unless %w[backup restore list-service-ids display-backups].include?(command)
 case command
 when 'backup'
   if $stdin.tty?
@@ -42,7 +42,6 @@ rescue Fog::Errors::LoadError => e
   usage
 end
 
-
 case command
 when 'backup'
   backup_data = $stdin.read
@@ -63,6 +62,33 @@ when 'list-service-ids'
     service_ids
   }
   puts service_ids
+when 'display-backups'
+  simultaneous_downloads = 5
+  require 'thread'
+  work_q = Queue.new
+  bucket.files.each{|file| work_q.push(file) }
+  workers = (0...simultaneous_downloads).map do
+    Thread.new do
+      begin
+        while file = work_q.pop(true)
+          begin
+            if file.key =~ %r{^dingo-postgresql-clusterdata-backup-(.*).json$}
+              json_str = file.body
+              backup_data = JSON.parse(json_str)
+              instance_id = backup_data['instance_id']
+              space_guid = backup_data['space_guid']
+              name = backup_data['service_instance_name'] || 'no-name'
+              puts "#{name}\t| #{instance_id} | #{space_guid}"
+            end
+          rescue JSON::ParserError
+            $stderr.puts "Failed to parse #{file.key}: #{json_str}"
+          end
+        end
+      rescue ThreadError
+      end
+    end
+  end
+  workers.map(&:join)
 when 'restore'
   instance_ids = $stdin.readlines.map(&:strip)
   errors = false

--- a/exe/dingo-postgresql-clusterdata-backup
+++ b/exe/dingo-postgresql-clusterdata-backup
@@ -119,7 +119,7 @@ when 'find-by-name'
               space_guid = backup_data['space_guid']
               name = backup_data['service_instance_name'] || 'no-name'
               if name == find_name && space_guid == find_space_guid
-                puts instance_id
+                puts backup_data.to_json
                 exit 0
               end
             end

--- a/exe/dingo-postgresql-clusterdata-backup
+++ b/exe/dingo-postgresql-clusterdata-backup
@@ -4,13 +4,13 @@ require 'fog'
 require 'json'
 
 def usage
-  $stderr.puts "USAGE: FOG_RC=path/to/fog.yml dingo-postgresql-clusterdata-backup [backup|restore|list-service-ids]"
+  $stderr.puts "USAGE: FOG_RC=path/to/fog.yml dingo-postgresql-clusterdata-backup [backup|restore|list-service-ids|display-backups|find-by-name]"
   exit 1
 end
 
 command=ARGV.shift
 usage if command.nil?
-usage unless %w[backup restore list-service-ids display-backups].include?(command)
+usage unless %w[backup restore list-service-ids display-backups find-by-name].include?(command)
 case command
 when 'backup'
   if $stdin.tty?
@@ -20,6 +20,11 @@ when 'backup'
 when 'restore'
   if $stdin.tty?
     $stderr.puts 'restore command expects STDIN instance_id'
+    exit 1
+  end
+when 'find-by-name'
+  if $stdin.tty?
+    $stderr.puts 'find-by-name command expects STDIN json {"space_guid": "GUID", "name": "NAME"}'
     exit 1
   end
 end
@@ -89,6 +94,46 @@ when 'display-backups'
     end
   end
   workers.map(&:join)
+when 'find-by-name'
+  input = JSON.parse($stdin.read)
+  find_name = input['name']
+  find_space_guid = input['space_guid']
+  if find_name.nil? || find_name == "" || find_space_guid.nil? || find_space_guid == ""
+    $stderr.puts 'find-by-name command expects STDIN json {"space_guid": "GUID", "name": "NAME"}'
+    exit 1
+  end
+
+  simultaneous_downloads = 5
+  require 'thread'
+  work_q = Queue.new
+  bucket.files.each{|file| work_q.push(file) }
+  workers = (0...simultaneous_downloads).map do
+    Thread.new do
+      begin
+        while file = work_q.pop(true)
+          begin
+            if file.key =~ %r{^dingo-postgresql-clusterdata-backup-(.*).json$}
+              json_str = file.body
+              backup_data = JSON.parse(json_str)
+              instance_id = backup_data['instance_id']
+              space_guid = backup_data['space_guid']
+              name = backup_data['service_instance_name'] || 'no-name'
+              if name == find_name && space_guid == find_space_guid
+                puts instance_id
+                exit 0
+              end
+            end
+          rescue JSON::ParserError
+            $stderr.puts "Failed to parse #{file.key}: #{json_str}"
+          end
+        end
+      rescue ThreadError
+      end
+    end
+  end
+  workers.map(&:join)
+  $stderr.puts("service instance not found for space_guid #{find_space_guid} and name #{find_name}")
+  exit 1
 when 'restore'
   instance_ids = $stdin.readlines.map(&:strip)
   errors = false


### PR DESCRIPTION
`find-by-name` consumes `{"space_guid": "GUID", "name": "NAME"}` via STDIN and searches thru clusterdata backup to find a matching JSON and returns it to STDOUT.
